### PR TITLE
Remove biorthogonal code for now. Calculate cost function efficiently

### DIFF
--- a/src/Backend/boundarymps.jl
+++ b/src/Backend/boundarymps.jl
@@ -554,14 +554,6 @@ function virtual_index_transformers(
 end
 
 function default_cache_prep_function(
-    alg::Algorithm"biorthogonal",
-    bmpsc::BoundaryMPSCache,
-    partitionpair,
-)
-    bmpsc = delete_partition_messages!(bmpsc, first(partitionpair))
-    return bmpsc
-end
-function default_cache_prep_function(
     alg::Algorithm"orthogonal",
     bmpsc::BoundaryMPSCache,
     partitionpair,

--- a/src/expect.jl
+++ b/src/expect.jl
@@ -42,7 +42,7 @@ function ITensorNetworks.expect(alg::Algorithm"exact",
     observable::Tuple;
     kwargs...
 )
-    return expect(alg, ψ, [observable]; kwargs...)
+    return only(expect(alg, ψ, [observable]; kwargs...))
 end
 
 
@@ -61,10 +61,7 @@ function ITensorNetworks.expect(
     (cache!)=nothing,
     update_cache=isnothing(cache!),
     cache_update_kwargs=alg == Algorithm("bp") ? default_posdef_bp_update_kwargs(; cache_is_tree = is_tree(ψ)) : ITensorNetworks.default_cache_update_kwargs(alg),
-    cache_construction_kwargs=default_cache_construction_kwargs(
-        alg,
-        QuadraticFormNetwork(ψ),
-    ),
+    cache_construction_kwargs= (;),
     message_rank = nothing,
     kwargs...,
 )
@@ -72,8 +69,8 @@ function ITensorNetworks.expect(
     if alg == Algorithm("boundarymps") && !isnothing(message_rank)
         cache_construction_kwargs = merge(cache_construction_kwargs, (; message_rank))
     end
-    ψIψ = QuadraticFormNetwork(ψ)
     if isnothing(cache!)
+        ψIψ = QuadraticFormNetwork(ψ)
         cache! = Ref(cache(alg, ψIψ; cache_construction_kwargs...))
     end
 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -58,6 +58,7 @@ using ITensorMPS
 using ITensorNetworks
 using ITensorNetworks:
     AbstractBeliefPropagationCache,
+    AbstractFormNetwork,
     AbstractITensorNetwork,
     AbstractIndsNetwork,
     Indices,

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -75,8 +75,8 @@ function _get_one_sample(
     logq = 0
     for (i, partition) in enumerate(sorted_partitions)
 
-        norm_MPScache, p_over_q_approx, _logq, bit_string, =
-            sample_partition(norm_MPScache, partition, bit_string; kwargs...)
+        p_over_q_approx, _logq, bit_string, =
+            sample_partition!(norm_MPScache, partition, bit_string; kwargs...)
         vs = planargraph_vertices(norm_MPScache, partition)
         logq += _logq
 
@@ -88,9 +88,7 @@ function _get_one_sample(
 
         if i < length(sorted_partitions)
             next_partition = sorted_partitions[i+1]
-
-            ms = messages(norm_MPScache)
-
+            
             #Alternate fitting procedure here which is faster for small bond dimensions but slower for large
             projected_MPScache = update(Algorithm("ITensorMPS"),
                 projected_MPScache,
@@ -101,7 +99,7 @@ function _get_one_sample(
 
             for pe in pes
                 m = only(message(projected_MPScache, pe))
-                set!(ms, pe, [m, dag(prime(m))])
+                set_message!(norm_MPScache, pe, [m, dag(prime(m))])
             end
         end
 
@@ -155,13 +153,12 @@ function certify_samples(ψ::ITensorNetwork, probs_and_bitstrings::Vector{<:Name
 end
 
 #Sample along the column/ row specified by pv with the left incoming MPS message input and the right extractable from the cache
-function sample_partition(
+function sample_partition!(
     ψIψ::BoundaryMPSCache,
     partition,
     bit_string::Dictionary;
     kwargs...,
 )
-    ψIψ = copy(ψIψ)
     vs = sort(planargraph_vertices(ψIψ, partition))
     seq = PartitionEdge[PartitionEdge(vs[i] => vs[i-1]) for i in length(vs):-1:2]
     !isempty(seq) && partition_update!(ψIψ, seq)
@@ -193,5 +190,5 @@ function sample_partition(
 
     delete_partition_messages!(ψIψ, partition)
 
-    return ψIψ, first(traces), logq, bit_string
+    return first(traces), logq, bit_string
 end

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -161,13 +161,14 @@ function sample_partition(
     bit_string::Dictionary;
     kwargs...,
 )
+    ψIψ = copy(ψIψ)
     vs = sort(planargraph_vertices(ψIψ, partition))
+    seq = PartitionEdge[PartitionEdge(vs[i] => vs[i-1]) for i in length(vs):-1:2]
+    !isempty(seq) && partition_update!(ψIψ, seq)
     prev_v, traces = nothing, []
     logq = 0
     for v in vs
-        ψIψ =
-            !isnothing(prev_v) ? partition_update(ψIψ, [prev_v], [v]) :
-            partition_update(ψIψ, [v])
+        !isnothing(prev_v) && partition_update!(ψIψ, [PartitionEdge(prev_v => v)])
         env = environment(bp_cache(ψIψ), [(v, "operator")])
         seq = contraction_sequence(env; alg="optimal")
         ρ = contract(env; sequence=seq)


### PR DESCRIPTION
This PR makes several modifications to the BoundaryMPS backend.

1. The biorthogonal code is removed as it is not being utilized at the moment and too experimental to be considered stable.
2. The cost function for the fitting is inferred from the updated message tensor and not computed independently, saving wasted constractions
3. The bug noted in Issue #16 is fixed. 
4. If the bp_cache passed to the `boundarymps` constructor already has message tensors, those will be used to initialize the MPS messages instead of new ones.