### PR TITLE
Speed up apply

### DIFF
--- a/src/apply.jl
+++ b/src/apply.jl
@@ -130,7 +130,7 @@ function ITensors.apply(gate::ITensor,
     apply_kwargs = _default_apply_kwargs,
 )
     ψ, ψψ = copy(ψ), copy(ψψ)
-    return apply(gate, ψ, ψψ, apply_kwargs)
+    return apply!(gate, ψ, ψψ, apply_kwargs)
 end
 
 #Apply function for a single gate. All apply functions will pass through here


### PR DESCRIPTION
This PR simplifies some operations in the `apply` function to be O(1) instead of O(nqubits) and also creates an in-place version of `apply!`. 

Noticeable speedups are obtained when doing time evolution in large systems. 

@MSRudolph 