### PR TITLE
fixed typo in gate names

### DIFF
--- a/examples/time-evolution.ipynb
+++ b/examples/time-evolution.ipynb
@@ -47,9 +47,9 @@
     "\n",
     "# pauli rotations are tuples like `(pauli_string, [site_labels], parameter)`\n",
     "layer = []\n",
-    "append!(layer, (\"RX\", [v], 2*hx*dt) for v in vertices(g))\n",
-    "append!(layer, (\"RZ\", [v], 2*hz*dt) for v in vertices(g))\n",
-    "append!(layer, (\"RZZ\", pair, 2*J*dt) for pair in edges(g));"
+    "append!(layer, (\"Rx\", [v], 2*hx*dt) for v in vertices(g))\n",
+    "append!(layer, (\"Rz\", [v], 2*hz*dt) for v in vertices(g))\n",
+    "append!(layer, (\"Rzz\", pair, 2*J*dt) for pair in edges(g));"
    ]
   },
   {
@@ -208,7 +208,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.11.2",
+   "display_name": "Julia 1.11.5",
    "language": "julia",
    "name": "julia-1.11"
   },
@@ -216,7 +216,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.11.2"
+   "version": "1.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There was a small typo in the definition of the gates in the example notebook `time-evolution.ipynb`. I changed `"RX"` to `"Rx"`, etc.