### PR TITLE
Posdef updatecache() default

### DIFF
--- a/src/Backend/beliefpropagation.jl
+++ b/src/Backend/beliefpropagation.jl
@@ -22,12 +22,12 @@ function default_bp_update_maxiter(cache_is_tree::Bool = false)
 end
 
 """
-    updatecache(bp_cache::BeliefPropagationCache; maxiter::Int64, tol::Number, message_update_kwargs = (; message_update_function = default_message_update))
+    updatecache(bp_cache::BeliefPropagationCache; maxiter::Int64, tol::Number, message_update_kwargs = (; message_update_function = default_posdef_message_update_function))
 
 Update the message tensors inside a bp-cache, running over the graph up to maxiter times until convergence to the desired tolerance `tol`.
 If the cache is positive definite, the message update function can
 """
-function updatecache(bp_cache; maxiter=default_bp_update_maxiter(is_tree(partitioned_graph(bp_cache))), tol=_default_bp_update_tol, message_update_kwargs=(; message_update_function=default_message_update))
+function updatecache(bp_cache; maxiter=default_bp_update_maxiter(is_tree(partitioned_graph(bp_cache))), tol=_default_bp_update_tol, message_update_kwargs=(; message_update_function=default_posdef_message_update_function))
     return update(bp_cache; maxiter, tol, message_update_kwargs)
 end
 

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -15,7 +15,9 @@ function ITensors.apply(
     kwargs...,
 )
     ψψ = build_bp_cache(ψ; cache_update_kwargs = bp_update_kwargs)
-    ψ, ψψ, truncation_errors = apply(circuit, ψ, ψψ; kwargs...)
+
+    ψ, ψψ, truncation_errors = apply(circuit, ψ, ψψ; update_cache = false, kwargs...)
+
     return ψ, truncation_errors
 end
 
@@ -91,7 +93,9 @@ function ITensors.apply(
 
     end
 
-    ψψ = updatecache(ψψ; bp_update_kwargs...)
+    if update_cache
+        ψψ = updatecache(ψψ; bp_update_kwargs...)
+    end
 
     return ψ, ψψ, truncation_errors
 end
@@ -109,7 +113,7 @@ function ITensors.apply(
     bp_update_kwargs = default_posdef_bp_update_kwargs(; cache_is_tree = is_tree(ψ)),
 )
     ψ, ψψ, truncation_error =
-        apply(gate, ψ, build_bp_cache(ψ; cache_update_kwargs = bp_update_kwargs); apply_kwargs)
+        apply(gate, ψ, build_bp_cache(ψ; cache_update_kwargs = bp_update_kwargs); apply_kwargs, update_cache = false)
     # because the cache is not passed, we return the state only
     return ψ, truncation_error
 end
@@ -124,7 +128,8 @@ function ITensors.apply(
     ψ::ITensorNetwork,
     ψψ::BeliefPropagationCache;
     apply_kwargs = _default_apply_kwargs,
-    bp_update_kwargs = default_posdef_bp_update_kwargs(; cache_is_tree = is_tree(ψ))
+    bp_update_kwargs = default_posdef_bp_update_kwargs(; cache_is_tree = is_tree(ψ)),
+    update_cache = true,
 )
     ψ, ψψ, truncation_error = apply(
         toitensor(gate, siteinds(ψ)),
@@ -132,7 +137,9 @@ function ITensors.apply(
         ψψ;
         apply_kwargs,
     )
-    ψψ = updatecache(ψψ; bp_update_kwargs...)
+    if update_cache
+        ψψ = updatecache(ψψ; bp_update_kwargs...)
+    end
     return ψ, ψψ, truncation_error
 end
 
@@ -141,13 +148,20 @@ end
 
 Apply a single gate in the form of an ITensor to the network with a pre-initialised bp cache. The gate should be of the form (gate_str::String, vertices_to_act_on::Union{Vector, NamedEdge}, optional_parameter::Number). Apply kwargs should be a NamedTuple containing desired maxdim and cutoff.
 """
-function ITensors.apply(gate::ITensor,
+function ITensors.apply(
+    gate::ITensor,
     ψ::AbstractITensorNetwork,
     ψψ::BeliefPropagationCache;
     apply_kwargs = _default_apply_kwargs,
+    bp_update_kwargs = default_posdef_bp_update_kwargs(; cache_is_tree = is_tree(ψ)),
+    update_cache = true,
 )
     ψ, ψψ = copy(ψ), copy(ψψ)
-    return apply!(gate, ψ, ψψ; apply_kwargs)
+    ψ, ψψ, truncation_error = apply!(gate, ψ, ψψ; apply_kwargs)
+    if update_cache
+        ψψ = updatecache(ψψ; bp_update_kwargs...)
+    end
+    return ψ, ψψ, truncation_error
 end
 
 #Apply function for a single gate. All apply functions will pass through here

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -16,7 +16,7 @@ function ITensors.apply(
 )
     ψψ = build_bp_cache(ψ; cache_update_kwargs = bp_update_kwargs)
 
-    ψ, ψψ, truncation_errors = apply(circuit, ψ, ψψ; update_cache = false, kwargs...)
+    ψ, ψψ, truncation_errors = apply(circuit, ψ, ψψ; kwargs...)
 
     return ψ, truncation_errors
 end


### PR DESCRIPTION
If not careful, we would accidentally not use the non-posef update scheme, but only sometimes, because the `apply()` function would always update with the posdef scheme at the end. 