### PR TITLE
Speed up expect

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "4de3b72a-362e-43dd-83ff-3f381eda9f9c"
 authors = ["JoeyT1994 <jtindall@flatironinstitute.org>", "MSRudolph <manuel.rudolph@web.de>","and contributors"]
 description = "A Julia package for simulating quantum circuits and dynamics with tensor networks of near-arbritrary topology."
 license = "MIT"
-version = "0.1.02"
+version = "0.1.03"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/Backend/abstractbeliefpropagationcache.jl
+++ b/src/Backend/abstractbeliefpropagationcache.jl
@@ -180,27 +180,6 @@ function update_iteration(
 end
 
 """
-Do parallel updates between groups of edges of all message tensors
-Currently we send the full message tensor data struct to update for each edge_group. But really we only need the
-mts relevant to that group.
-"""
-function update_iteration(
-        alg::Algorithm"bp",
-        bpc::AbstractBeliefPropagationCache,
-        edge_groups::Vector{<:Vector{<:AbstractEdge}};
-        (update_diff!) = nothing,
-    )
-    new_mts = empty(messages(bpc))
-    for edges in edge_groups
-        bpc_t = update_iteration(alg.kwargs.message_update_alg, bpc, edges; (update_diff!))
-        for e in edges
-            set!(new_mts, e, message(bpc_t, e))
-        end
-    end
-    return set_messages(bpc, new_mts)
-end
-
-"""
 More generic interface for update, with default params
 """
 function update(alg::Algorithm"bp", bpc::AbstractBeliefPropagationCache)

--- a/src/expect.jl
+++ b/src/expect.jl
@@ -82,6 +82,7 @@ function expect(
     end
     op_string_f = v -> v ∈ obs_vs ? op_strings[findfirst(x -> x == v, obs_vs)] : "I"
 
+    #TODO: If there are a lot of tensors here, (more than 100 say), we need to think about defining a custom sequence as optimal may be too slow
     incoming_ms = incoming_messages(cache, steiner_vs)
     ψIψ_tensors = ITensor[norm_factors(network(cache), steiner_vs); incoming_ms]
     denom_seq = contraction_sequence(ψIψ_tensors; alg = "optimal")

--- a/src/expect.jl
+++ b/src/expect.jl
@@ -84,11 +84,11 @@ function expect(
 
     incoming_ms = incoming_messages(cache, steiner_vs)
     ψIψ_tensors = ITensor[norm_factors(network(cache), steiner_vs); incoming_ms]
-    denom_seq = contraction_sequence(ψIψ_tensors; alg = "einexpr", optimizer = Greedy())
+    denom_seq = contraction_sequence(ψIψ_tensors; alg = "optimal")
     denom = contract(ψIψ_tensors; sequence = denom_seq)[]
 
     ψOψ_tensors = ITensor[norm_factors(network(cache), steiner_vs; op_strings = op_string_f); incoming_ms]
-    numer_seq = contraction_sequence(ψOψ_tensors; alg = "einexpr", optimizer = Greedy())
+    numer_seq = contraction_sequence(ψOψ_tensors; alg = "optimal")
     numer = contract(ψOψ_tensors; sequence = numer_seq)[]
 
     return coeff * numer / denom

--- a/src/symmetric_gauge.jl
+++ b/src/symmetric_gauge.jl
@@ -136,6 +136,6 @@ end
     - The truncated `tns::TensorNetworkState`.
 """
 function ITensors.truncate(tns::TensorNetworkState, args...; alg, kwargs...)
-    algorithm_check(tns, alg)
+    algorithm_check(tns, "truncate", alg)
     return truncate(Algorithm(alg), tns, args...; kwargs...)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,18 +43,18 @@ function algorithm_check(tns::Union{AbstractBeliefPropagationCache, TensorNetwor
             return error("Expected BeliefPropagationCache or TensorNetworkState for 'loop correctiom' algorithm, got $(typeof(tns))")
         end
 
-        if f ∈ ["normalize", "expect", "entanglement", "sample"]
+        if f ∈ ["normalize", "expect", "entanglement", "sample", "truncate"]
             return error("Loop correction-based contraction not supported for this functionality yet")
         end
     elseif alg == "boundarymps"
         if !((tns isa BoundaryMPSCache) || (tns isa TensorNetworkState))
             return error("Expected BoundaryMPSCache or TensorNetworkState for 'boundarymps' algorithm, got $(typeof(tns))")
         end
-        if f ∈ ["normalize", "entanglement"]
+        if f ∈ ["normalize", "entanglement", "truncate"]
             return error("boundarymps contraction not supported for this functionality yet")
         end
     elseif alg == "exact"
-        if f ∈ ["normalize", "entanglement", "sample"]
+        if f ∈ ["normalize", "entanglement", "sample", "truncate"]
             return error("exact contraction not supported for this functionality yet")
         end
     elseif alg ∉ ["exact", "bp", "loopcorrections", "boundarymps"]


### PR DESCRIPTION
This PR improves the expect function for `alg = "bp" and alg = "boundarymps"`  by using a better sequence finder. A custom one (based on the Steiner tree) should be used for much larger trees.

A redundant function is also removed and some errors are fixed.