### PR TITLE
Better Truncate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "4de3b72a-362e-43dd-83ff-3f381eda9f9c"
 authors = ["JoeyT1994 <jtindall@flatironinstitute.org>", "MSRudolph <manuel.rudolph@web.de>","and contributors"]
 description = "A Julia package for simulating quantum circuits and dynamics with tensor networks of near-arbritrary topology."
 license = "MIT"
-version = "0.1.04"
+version = "0.1.05"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/TensorNetworkQuantumSimulator.jl
+++ b/src/TensorNetworkQuantumSimulator.jl
@@ -22,6 +22,7 @@ include("inner.jl")
 include("normalize.jl")
 include("sampling.jl")
 include("symmetric_gauge.jl")
+include("truncate.jl")
 
 
 export

--- a/src/inner.jl
+++ b/src/inner.jl
@@ -9,7 +9,8 @@ end
 """
     inner(ψ::TensorNetworkState, ϕ::TensorNetworkState; alg, kwargs...)
 
-    Compute the inner product between two TensorNetworkStates using the specified algorithm.
+    Compute the inner product between two different TensorNetworkStates using the specified algorithm.
+    If you want the norm_squared of a tensornetwork state ψ, use `norm_sqr(ψ; alg, kwargs...)` instead.
     The two states should have the same graph structure and physical indices on each site.
 
     # Arguments

--- a/src/symmetric_gauge.jl
+++ b/src/symmetric_gauge.jl
@@ -106,36 +106,3 @@ function entanglement(alg::Algorithm"bp", tns::TensorNetworkState, e::NamedEdge;
     bp_cache = update(bp_cache)
     return entanglement(bp_cache, e)
 end
-
-function symmetric_truncate!(bp_cache::BeliefPropagationCache; maxdim = nothing, cutoff = nothing, kwargs...)
-    return symmetric_gauge!(bp_cache; maxdim, cutoff, kwargs...)
-end
-
-function symmetric_truncate(bp_cache::BeliefPropagationCache; maxdim = nothing, cutoff = nothing, kwargs...)
-    bp_cache = copy(bp_cache)
-    return symmetric_truncate!(bp_cache; maxdim, cutoff, kwargs...)
-end
-
-function symmetric_truncate(alg::Algorithm"bp", tns::TensorNetworkState; maxdim = nothing, cutoff = nothing, cache_update_kwargs = (; maxiter = 40), kwargs...)
-    bp_cache = BeliefPropagationCache(tns)
-    bp_cache = update(bp_cache; cache_update_kwargs...)
-    return network(symmetric_truncate(bp_cache; maxdim, cutoff, kwargs...))
-end
-
-"""
-    symmetric_truncate(tns::TensorNetworkState; alg, args...; kwargs...)
-    Truncate the bonds of a `TensorNetworkState` using the specified algorithm.
-    The supported algorithms are:
-    - `"bp"`: Truncate using Belief Propagation.
-    # Arguments
-    - `tns::TensorNetworkState`: The tensor network state to be truncated.
-    - `alg::String`: The truncation algorithm to use. Default is `nothing`, so it must be specified explicitly.
-    - `args...`: Additional positional arguments specific to the chosen algorithm. These include cache update arguments in the form of a `NamedTuple` cache_update_kwargs.
-    - `kwargs...`: Additional keyword arguments specific to the chosen algorithm. These include options like `maxdim` and `cutoff` for bond dimension truncation.
-    # Returns
-    - The truncated `tns::TensorNetworkState`.
-"""
-function symmetric_truncate(tns::TensorNetworkState, args...; alg, kwargs...)
-    algorithm_check(tns, "symmetric_truncate", alg)
-    return symmetric_truncate(Algorithm(alg), tns, args...; kwargs...)
-end

--- a/src/symmetric_gauge.jl
+++ b/src/symmetric_gauge.jl
@@ -107,23 +107,23 @@ function entanglement(alg::Algorithm"bp", tns::TensorNetworkState, e::NamedEdge;
     return entanglement(bp_cache, e)
 end
 
-function truncate!(bp_cache::BeliefPropagationCache; maxdim = nothing, cutoff = nothing, kwargs...)
+function symmetric_truncate!(bp_cache::BeliefPropagationCache; maxdim = nothing, cutoff = nothing, kwargs...)
     return symmetric_gauge!(bp_cache; maxdim, cutoff, kwargs...)
 end
 
-function ITensors.truncate(bp_cache::BeliefPropagationCache; maxdim = nothing, cutoff = nothing, kwargs...)
+function symmetric_truncate(bp_cache::BeliefPropagationCache; maxdim = nothing, cutoff = nothing, kwargs...)
     bp_cache = copy(bp_cache)
-    return truncate!(bp_cache; maxdim, cutoff, kwargs...)
+    return symmetric_truncate!(bp_cache; maxdim, cutoff, kwargs...)
 end
 
-function ITensors.truncate(alg::Algorithm"bp", tns::TensorNetworkState; maxdim = nothing, cutoff = nothing, cache_update_kwargs = (; maxiter = 40), kwargs...)
+function symmetric_truncate(alg::Algorithm"bp", tns::TensorNetworkState; maxdim = nothing, cutoff = nothing, cache_update_kwargs = (; maxiter = 40), kwargs...)
     bp_cache = BeliefPropagationCache(tns)
     bp_cache = update(bp_cache; cache_update_kwargs...)
-    return network(truncate(bp_cache; maxdim, cutoff, kwargs...))
+    return network(symmetric_truncate(bp_cache; maxdim, cutoff, kwargs...))
 end
 
 """
-    truncate(tns::TensorNetworkState; alg, args...; kwargs...)
+    symmetric_truncate(tns::TensorNetworkState; alg, args...; kwargs...)
     Truncate the bonds of a `TensorNetworkState` using the specified algorithm.
     The supported algorithms are:
     - `"bp"`: Truncate using Belief Propagation.
@@ -135,7 +135,7 @@ end
     # Returns
     - The truncated `tns::TensorNetworkState`.
 """
-function ITensors.truncate(tns::TensorNetworkState, args...; alg, kwargs...)
-    algorithm_check(tns, "truncate", alg)
-    return truncate(Algorithm(alg), tns, args...; kwargs...)
+function symmetric_truncate(tns::TensorNetworkState, args...; alg, kwargs...)
+    algorithm_check(tns, "symmetric_truncate", alg)
+    return symmetric_truncate(Algorithm(alg), tns, args...; kwargs...)
 end

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -1,0 +1,25 @@
+default_truncate_alg(tns::TensorNetworkState) = nothing
+
+function ITensors.truncate(bpc::BeliefPropagationCache; bp_update_kwargs = default_bp_update_kwargs(bpc), maxdim::Integer, cutoff::Number = nothing)
+    bpc = copy(bpc)
+    s = siteinds(network(bpc))
+    apply_kwargs = (; maxdim, cutoff)
+    for e in edges(bpc)
+        g1, g2 = reduce(*, [ITensors.op("I", sv) for sv in s[src(e)]]), reduce(*, [ITensors.op("I", sv) for sv in s[dst(e)]])
+        apply_gate!(g1*g2, bpc; v⃗ = [src(e), dst(e)], apply_kwargs)
+        bpc = update(bpc; bp_update_kwargs...)
+    end
+    return bpc
+end
+
+function ITensors.truncate(alg::Algorithm"bp", tns::TensorNetworkState; kwargs...)
+    bp_cache = BeliefPropagationCache(tns)
+    bp_cache = truncate(bp_cache; kwargs...)
+    return network(bp_cache)
+end
+
+function ITensors.truncate(tns::TensorNetworkState; alg = default_truncate_alg(tns), kwargs...)
+    algorithm_check(tns, "truncate", alg)
+    return truncate(Algorithm(alg), tns; kwargs...)
+end
+

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -12,10 +12,57 @@ function ITensors.truncate(bpc::BeliefPropagationCache; bp_update_kwargs = defau
     return bpc
 end
 
+function ITensors.truncate(bmps_cache::BoundaryMPSCache; maxdim::Integer, cutoff::Number = nothing)
+    bmps_cache = copy(bmps_cache)
+    s = siteinds(network(bmps_cache))
+    apply_kwargs = (; maxdim, cutoff)
+
+    ps = sort(partitionvertices(supergraph(bmps_cache)); by = v -> parent(v))
+    for (i, p) in enumerate(ps)
+        g = partition_graph(bmps_cache, p)
+        leaves = leaf_vertices(g)
+        seq = a_star(g, last(leaves), first(leaves))
+        !isempty(seq) && update_partition!(bmps_cache, seq)
+        for e in reverse.(reverse(seq))
+            g1, g2 = reduce(*, [ITensors.op("I", sv) for sv in s[src(e)]]), reduce(*, [ITensors.op("I", sv) for sv in s[dst(e)]])
+            envs = incoming_messages(bmps_cache, [src(e), dst(e)])
+            ρv1, ρv2  = ITensorNetworks.full_update_bp(g1*g2, tensornetwork(network(bmps_cache)), [src(e), dst(e)]; envs, apply_kwargs...)
+            setindex_preserve_graph!(bmps_cache, normalize(ρv1), src(e))
+            setindex_preserve_graph!(bmps_cache, normalize(ρv2), dst(e))
+            update_partition!(bmps_cache, [e])
+        end
+
+        if i != length(ps)
+            bmps_cache = update(bmps_cache; alg = "bp", edge_sequence = [PartitionEdge(parent(ps[i]) => parent(ps[i+1]))], maxiter = 1)
+        end
+    end
+
+    return bmps_cache
+end
+
 function ITensors.truncate(alg::Algorithm"bp", tns::TensorNetworkState; kwargs...)
     bp_cache = BeliefPropagationCache(tns)
+    bp_cache = update(bp_cache)
     bp_cache = truncate(bp_cache; kwargs...)
     return network(bp_cache)
+end
+
+function ITensors.truncate(alg::Algorithm"boundarymps", tns::TensorNetworkState; mps_bond_dimension::Integer, kwargs...)
+    bmps_cache = BoundaryMPSCache(tns, mps_bond_dimension; partition_by = "row")
+    leaves = leaf_vertices(partitions_graph(supergraph(bmps_cache)))
+    seq = PartitionEdge.(a_star(partitions_graph(supergraph(bmps_cache)), last(leaves), first(leaves)))
+    bmps_cache = update(bmps_cache; alg = "bp", edge_sequence = seq, maxiter = 1)
+    bmps_cache = truncate(bmps_cache; kwargs...)
+
+    tns = network(bmps_cache)
+
+    bmps_cache = BoundaryMPSCache(tns, mps_bond_dimension; partition_by = "col")
+    leaves = leaf_vertices(partitions_graph(supergraph(bmps_cache)))
+    seq = PartitionEdge.(a_star(partitions_graph(supergraph(bmps_cache)), last(leaves), first(leaves)))
+    bmps_cache = update(bmps_cache; alg = "bp", edge_sequence = seq, maxiter = 1)
+    bmps_cache = truncate(bmps_cache; kwargs...)
+
+    return network(bmps_cache)
 end
 
 function ITensors.truncate(tns::TensorNetworkState; alg = default_truncate_alg(tns), kwargs...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,7 +47,7 @@ function algorithm_check(tns::Union{AbstractBeliefPropagationCache, TensorNetwor
         if !((tns isa BoundaryMPSCache) || (tns isa TensorNetworkState))
             return error("Expected BoundaryMPSCache or TensorNetworkState for 'boundarymps' algorithm, got $(typeof(tns))")
         end
-        if f ∈ ["normalize", "entanglement", "truncate"]
+        if f ∈ ["normalize", "entanglement"]
             return error("boundarymps contraction not supported for this functionality yet")
         end
     elseif alg == "exact"


### PR DESCRIPTION
This PR introduces improvements to the `truncate` function that both make it more accurate (for `alg = "bp"`) and allows `boundarymps` support via `full_update`.

