### PR TITLE
Allow TypeParameterAccessors 0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -47,7 +47,7 @@ SplitApplyCombine = "1.2.3"
 Statistics = "1.11.1"
 StatsBase = "0.34.4"
 TensorOperations = "5.2"
-TypeParameterAccessors = "0.3.10"
+TypeParameterAccessors = "0.3.10, 0.4"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
Allow latest version of TypeParameterAccessors to remove the StridedViews compat restriction.