### PR TITLE
Fix steiner_tree method ambiguity for integer-labeled vertices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorNetworkQuantumSimulator"
 uuid = "4de3b72a-362e-43dd-83ff-3f381eda9f9c"
 license = "MIT"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["JoeyT1994 <jtindall@flatironinstitute.org>", "and contributors"]
 description = "A Julia package for quantum simulation with tensor networks of near-arbitrary topology."
 

--- a/src/TensorNetworks/abstracttensornetwork.jl
+++ b/src/TensorNetworks/abstracttensornetwork.jl
@@ -20,7 +20,6 @@ NamedGraphs.vertices(tn::AbstractTensorNetwork) = NamedGraphs.vertices(graph(tn)
 NamedGraphs.edges(tn::AbstractTensorNetwork) = NamedGraphs.edges(graph(tn))
 NamedGraphs.edgetype(tn::AbstractTensorNetwork) = NamedGraphs.edgetype(graph(tn))
 NamedGraphs.vertextype(tn::AbstractTensorNetwork) = NamedGraphs.vertextype(graph(tn))
-NamedGraphs.steiner_tree(tn::AbstractTensorNetwork, vs) = NamedGraphs.steiner_tree(graph(tn), vs)
 
 virtualinds(tn::AbstractTensorNetwork, e::NamedEdge) = ITensors.commoninds(tn[src(e)], tn[dst(e)])
 virtualind(tn::AbstractTensorNetwork, e::NamedEdge) = only(virtualinds(tn, e))


### PR DESCRIPTION
## Summary

Multi-site `expect` and `rdm` with `alg = "bp"` threw an ambiguous-method error on networks with integer-labeled vertices, because the `NamedGraphs.steiner_tree(tn::AbstractTensorNetwork, vs)` overload tied with `NamedGraphs.steiner_tree(::AbstractNamedGraph, ::Vector{<:Integer})`. `AbstractTensorNetwork` already inherits a working `steiner_tree` from NamedGraphs, so this drops the redundant overload.

```julia
using TensorNetworkQuantumSimulator
using NamedGraphs.NamedGraphGenerators: named_cycle_graph

g = named_cycle_graph(4)  # integer-labeled vertices
ψ = random_tensornetworkstate(g; bond_dimension = 2)
expect(ψ, ("ZZ", [1, 2]); alg = "bp")  # before: MethodError: steiner_tree(...) is ambiguous
```
